### PR TITLE
Remove project that no longer exists from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ There are several example plots in the `examples/` directory. To build the examp
 ```yaml
 packages:
 - '.'
-- 'examples/lib'
 - 'test'
 ```
 


### PR DESCRIPTION
I should have fixed this in the other README PR. This library no longer exists, so we should remove it from `stack.yaml`.
