### PR TITLE
Update upper bound for hashable.

### DIFF
--- a/plots.cabal
+++ b/plots.cabal
@@ -59,7 +59,7 @@ library
     transformers,
     filepath,
     fingertree,
-    hashable      >= 1.1 && < 1.4,
+    hashable      >= 1.1 && < 1.5,
     lens          >= 4.6 && < 5.2,
     linear        >= 1.2 && < 2.0,
     monoid-extras >= 0.3 && < 0.7,


### PR DESCRIPTION
No problems occurred when building with a recent version of the hashable package.